### PR TITLE
altered architecture; added caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,8 @@ headlines written out, and often include a picture or some article text
 as well, providing a little more of a clue about the content of the
 target article. Also, limiting the number of previews fetched per page
 makes the extension both faster to run and a more polite netizen.
+
+### Known Issues
+
+ * Script doesn't properly work on pages opened with "open link in new tab"
+   context menu item.

--- a/apv_popup.html
+++ b/apv_popup.html
@@ -1,0 +1,14 @@
+<html>
+<head>
+    <title>Associated Preview Popup</title>
+    <style>
+body { text-align: center; }
+    </style>
+</head>
+<body>
+    <img src="images/apv_logo_128.png">
+    <p>Cache size: <span id="size"></span></p>
+    <button id="clear_cache">Clear Cache</button>
+    <script src="apv_popup.js"></script>
+</body>
+</html>

--- a/apv_popup.js
+++ b/apv_popup.js
@@ -1,0 +1,39 @@
+/* apv_popup.js
+ * 
+ * Associated Preview browser_action icon popup script
+ * 
+ * 2020-06-27
+ */
+ 
+const KILO = 1024;
+const MEGA = 1024 * 1024;
+
+let size_span = document.getElementById("size");
+let clear_butt = document.getElementById("clear_cache");
+
+function scale_size(x) {
+    if (x < KILO) {
+        return x.toString() + " bytes";
+    } else if (x < MEGA) {
+        let v = x / KILO;
+        return v.toPrecision(3) + ' Kb';
+    } else {
+        let v = x / MEGA;
+        return v.toPrecision(3) + ' Mb';
+    }
+}
+
+function report_cache_size() {
+    chrome.storage.local.getBytesInUse(null,
+        function(biu) {
+            size_span.innerHTML = scale_size(biu);
+        }
+    );
+}
+
+function clear_cache() {
+    chrome.storage.local.clear(report_cache_size);
+}
+
+report_cache_size();
+clear_butt.addEventListener("click", clear_cache);

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,29 @@
+{
+    "manifest_version": 2,
+    
+    "name":        "Associated Preview",
+    "version":     "0.1",
+    "description": "Provide pop-up article previews on linked AP News website articles.",
+    
+    "permissions": [ "storage" ],
+
+    "icons": {
+        "16": "images/apv_logo_16.png",
+        "32": "images/apv_logo_32.png",
+        "48": "images/apv_logo_48.png",
+        "128": "images/apv_logo_128.png"
+    },
+    
+    "browser_action": {
+        "default_popup": "apv_popup.html"
+    },
+    
+    "content_scripts": [
+        {
+            "matches":  [ "*://apnews.com/*" ],
+            "css":      [ "style.css" ],
+            "js":       [ "apv_content.js" ],
+            "run_at":   "document_end"
+        }
+    ]
+}

--- a/style.css
+++ b/style.css
@@ -20,6 +20,7 @@ div#apv_preview {
 }
 
 div#apv_preview h3 {
+    margin-top: 0; padding-top: 0;
     font-family: GoodOT-Cond,Arial Narrow,Arial,sans-serif;
 }
 div#apv_preview p {


### PR DESCRIPTION
The way previews are fetched/set was consolidated and simplified a bit.

The extension now caches generated previews (24 hours for articles; 4 hours for topics and feeds) and checks the local cache for unexpired previews before bothering the apnews.com servers with requests for content. Additionally, a popup has been added to the browser window icon showing current cache use and offering an option to clear the cache.